### PR TITLE
Update move_descriptions.h

### DIFF
--- a/src/data/text/move_descriptions.h
+++ b/src/data/text/move_descriptions.h
@@ -11,7 +11,7 @@ static const u8 sKarateChopDescription[] = _(
 
 static const u8 sDoubleSlapDescription[] = _(
 	"Repeatedly slaps the foe\n"
-	"2 to 5 times.");
+	"4 to 5 times.");
 
 static const u8 sCometPunchDescription[] = _(
 	"Repeatedly punches the foe\n"


### PR DESCRIPTION
Fixed Magma Storm's description. Sorry, I didn't know that it was working like in Gen. 5+