### PR TITLE
Hold Hands fix

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2851,7 +2851,7 @@ BattleScript_EffectDoNothing::
 	goto BattleScript_MoveEnd
 BattleScript_EffectHoldHands:
 	jumpifsideaffecting BS_TARGET, SIDE_STATUS_CRAFTY_SHIELD, BattleScript_ButItFailed
-	jumpifnotbattletype BATTLE_TYPE_TWO_OPPONENTS | BATTLE_TYPE_DOUBLE, BattleScript_ButItFailed
+	jumpifbyteequal gBattlerTarget, gBattlerAttacker, BattleScript_ButItFailed
 	attackanimation
 	waitanimation
 	goto BattleScript_MoveEnd


### PR DESCRIPTION
Better check for valid ally. If there isn't one, the target defaults to the attacker, causing the move to fail.