### PR TITLE
Add variable for debug menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ endif
 
 ifeq ($(DINFO),1)
 override CFLAGS += -g
+override CPP += -DDEBUG=1
 endif
 
 $(C_BUILDDIR)/%.o : $(C_SUBDIR)/%.c $$(c_dep)

--- a/include/battle_debug.h
+++ b/include/battle_debug.h
@@ -1,7 +1,12 @@
 #ifndef GUARD_BATTLE_DEBUG_H
 #define GUARD_BATTLE_DEBUG_H
 
+
+#if DEBUG == 1
 #define USE_BATTLE_DEBUG TRUE
+#else
+#define USE_BATTLE_DEBUG FALSE
+#endif
 
 void CB2_BattleDebugMenu(void);
 


### PR DESCRIPTION
This adds a variable that enables the debug menu only if DINFO=1 when running make.