### PR TITLE
Debug menu tied to BDEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,10 @@ endif
 
 ifeq ($(DINFO),1)
 override CFLAGS += -g
-override CPP += -DDEBUG=1
+endif
+
+ifeq ($(BDEBUG),1)
+override CPP += -DBDEBUG=1
 endif
 
 $(C_BUILDDIR)/%.o : $(C_SUBDIR)/%.c $$(c_dep)

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ endif
 
 ifeq ($(DINFO),1)
 override CFLAGS += -g
+override CPP += -DDEBUG=1
 endif
 
 $(C_BUILDDIR)/%.o : $(C_SUBDIR)/%.c $$(c_dep)

--- a/include/battle_debug.h
+++ b/include/battle_debug.h
@@ -1,7 +1,12 @@
 #ifndef GUARD_BATTLE_DEBUG_H
 #define GUARD_BATTLE_DEBUG_H
 
+
+#if DEBUG == 1
 #define USE_BATTLE_DEBUG TRUE
+#else
+#define USE_BATTLE_DEBUG FALSE
+#endif
 
 void CB2_BattleDebugMenu(void);
 

--- a/include/battle_debug.h
+++ b/include/battle_debug.h
@@ -2,7 +2,7 @@
 #define GUARD_BATTLE_DEBUG_H
 
 
-#if DEBUG == 1
+#if BDEBUG == 1
 #define USE_BATTLE_DEBUG TRUE
 #else
 #define USE_BATTLE_DEBUG FALSE


### PR DESCRIPTION
Makes it so the debug menu only shows if building with BDEBUG=1.