### PR TITLE
Make No Guard affect OHKO Moves (thanks to Squeetz/Breadcrumbs)

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8885,7 +8885,12 @@ static void Cmd_tryKO(void)
     else
     {
         u16 chance;
-        if (!(gStatuses3[gBattlerTarget] & STATUS3_ALWAYS_HITS))
+        if ((gBattleMons[gBattlerAttacker].ability == ABILITY_NO_GUARD || gBattleMons[gBattlerTarget].ability == ABILITY_NO_GUARD)
+         && (gBattleMons[gBattlerAttacker].level >= gBattleMons[gBattlerTarget].level))
+        {
+            chance = TRUE;
+        }
+        else if (!(gStatuses3[gBattlerTarget] & STATUS3_ALWAYS_HITS))
         {
             chance = gBattleMoves[gCurrentMove].accuracy + (gBattleMons[gBattlerAttacker].level - gBattleMons[gBattlerTarget].level);
             if (Random() % 100 + 1 < chance && gBattleMons[gBattlerAttacker].level >= gBattleMons[gBattlerTarget].level)


### PR DESCRIPTION
This PR fixes #247.

**EDIT**: I'm dumb. I should have clarified that the code comes straight from [Squeetz/Breadcrumbs](https://www.pokecommunity.com/member.php?u=400825). All the credits are his.