### PR TITLE
Fixed Ability Pop Up for Immunity-type abilities with Mold Breaker.

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3618,9 +3618,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u8 ability, u8 special, u16 moveA
 
                 BattleScriptPushCursor();
                 gBattlescriptCurrInstr = BattleScript_AbilityCuredStatus;
-                gBattleScripting.battler = battler;
-                gActiveBattler = battler;
-                gBattlerAbility = battler;
+                gBattleScripting.battler = gActiveBattler = gAbilityBattler = battler;
                 BtlController_EmitSetMonData(0, REQUEST_STATUS_BATTLE, 0, 4, &gBattleMons[gActiveBattler].status1);
                 MarkBattlerForControllerExec(gActiveBattler);
                 return effect;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3620,6 +3620,7 @@ u8 AbilityBattleEffects(u8 caseID, u8 battler, u8 ability, u8 special, u16 moveA
                 gBattlescriptCurrInstr = BattleScript_AbilityCuredStatus;
                 gBattleScripting.battler = battler;
                 gActiveBattler = battler;
+                gBattlerAbility = battler;
                 BtlController_EmitSetMonData(0, REQUEST_STATUS_BATTLE, 0, 4, &gBattleMons[gActiveBattler].status1);
                 MarkBattlerForControllerExec(gActiveBattler);
                 return effect;


### PR DESCRIPTION
When a mon with Mold Breaker caused a status move to another one with an Immunity-type ability such as that mon healed immediatly from it, the ability pop up would incorrectly show the for the Mold Breaker mon instead of the Immunity mon.

This affected the following abilities:
- Immunity
- Own Tempo
- Limber
- Insomnia
- Vital Spirit
- Water Veil
- Magma Armor
- Oblivious

Reported by @LOuroboros