### PR TITLE
Expanded Pokeball IDs for Pokémon caught.

### DIFF
--- a/berry_fix/payload/include/pokemon.h
+++ b/berry_fix/payload/include/pokemon.h
@@ -39,7 +39,7 @@ struct PokemonSubstruct3
 
     /*0x02*/ u16 metLevel:7;
     /*0x02*/ u16 metGame:4;
-    /*0x03*/ u16 pokeball:4;
+    /*0x03*/ u16 pokeball:5;
     /*0x03*/ u16 otGender:1;
 
     /*0x04*/ u32 hpIV:5;

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -42,7 +42,7 @@ struct PokemonSubstruct3
 
  /* 0x02 */ u16 metLevel:7;
  /* 0x02 */ u16 metGame:4;
- /* 0x03 */ u16 pokeball:4;
+ /* 0x03 */ u16 pokeball:5;
  /* 0x03 */ u16 otGender:1;
 
  /* 0x04 */ u32 hpIV:5;


### PR DESCRIPTION
Fix for #285 
Added a single bit to increase the max amount of Pokéballs shown in summary screen from 16 to 32.