### PR TITLE
Make Assurance's power be affected if the opponent hurts themself in confusion

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -5270,7 +5270,7 @@ static u16 CalcMoveBasePower(u16 move, u8 battlerAtk, u8 battlerDef)
             basePower *= 2;
         break;
     case EFFECT_ASSURANCE:
-        if (gProtectStructs[battlerAtk].physicalDmg != 0 || gProtectStructs[battlerAtk].specialDmg != 0)
+        if (gProtectStructs[battlerAtk].physicalDmg != 0 || gProtectStructs[battlerAtk].specialDmg != 0 || gProtectStructs[battlerDef].confusionSelfDmg != 0)
             basePower *= 2;
         break;
     case EFFECT_TRUMP_CARD:


### PR DESCRIPTION
Fixes #312 