### PR TITLE
Intimidate activates Defiant and Competitive

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6427,6 +6427,8 @@ BattleScript_IntimidateActivatesLoop:
 	playanimation BS_TARGET, B_ANIM_STATS_CHANGE, sB_ANIM_ARG1
 	printstring STRINGID_PKMNCUTSATTACKWITH
 	waitmessage 0x40
+	jumpifability BS_TARGET, ABILITY_DEFIANT, BattleScript_IntimidateActivatesDefiant
+	jumpifability BS_TARGET, ABILITY_COMPETITIVE, BattleScript_IntimidateActivatesCompetitive
 BattleScript_IntimidateActivatesLoopIncrement:
 	addbyte gBattlerTarget, 0x1
 	goto BattleScript_IntimidateActivatesLoop
@@ -6437,6 +6439,16 @@ BattleScript_IntimidatePrevented:
 	printstring STRINGID_PREVENTEDFROMWORKING
 	waitmessage 0x40
 	goto BattleScript_IntimidateActivatesLoopIncrement
+BattleScript_IntimidateActivatesDefiant:
+	setstatchanger STAT_ATK, 2, FALSE
+	call BattleScript_DefiantActivates
+	setstatchanger STAT_ATK, 1, TRUE
+	goto BattleScript_IntimidateActivatesLoopIncrement
+BattleScript_IntimidateActivatesCompetitive:
+	setstatchanger STAT_SPATK, 2, FALSE
+	call BattleScript_DefiantActivates
+	setstatchanger STAT_ATK, 1, TRUE
+ 	goto BattleScript_IntimidateActivatesLoopIncrement
 
 BattleScript_DroughtActivates::
 	pause 0x20


### PR DESCRIPTION
If a Pokemon with Defiant or Competitive is intimidated, its ability should activate.
![defiant](https://user-images.githubusercontent.com/28769716/79535658-2d511f00-80d2-11ea-9491-301c3bd831e3.gif)
