### PR TITLE
Razor Wind up to Gen4+ standard

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -192,7 +192,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_BOTH,
         .priority = 0,
-        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED,
+        .flags = FLAG_PROTECT_AFFECTED | FLAG_MIRROR_MOVE_AFFECTED | FLAG_KINGSROCK_AFFECTED | FLAG_HIGH_CRIT,
         .split = SPLIT_SPECIAL,
     },
 


### PR DESCRIPTION
In Gen2 and Gen4 onwards, Razor Wind has a higher Critical Hit chance.
https://bulbapedia.bulbagarden.net/wiki/Razor_Wind_(move)