### PR TITLE
Counter affected by Protect, not by Mirror Move

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -962,7 +962,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
         .secondaryEffectChance = 0,
         .target = MOVE_TARGET_DEPENDS,
         .priority = -5,
-        .flags = FLAG_MAKES_CONTACT | FLAG_MIRROR_MOVE_AFFECTED,
+        .flags = FLAG_MAKES_CONTACT | FLAG_PROTECT_AFFECTED,
         .split = SPLIT_PHYSICAL,
     },
 


### PR DESCRIPTION
Source: https://bulbapedia.bulbagarden.net/wiki/Counter_(move)