### PR TITLE
String Shot lowers speed twice from Gen6+

### DIFF
--- a/src/data/battle_moves.h
+++ b/src/data/battle_moves.h
@@ -1136,7 +1136,7 @@ const struct BattleMove gBattleMoves[MOVES_COUNT] =
 
     [MOVE_STRING_SHOT] =
     {
-        .effect = EFFECT_SPEED_DOWN,
+        .effect = EFFECT_SPEED_DOWN_2,
         .power = 0,
         .type = TYPE_BUG,
         .accuracy = 95,


### PR DESCRIPTION
https://bulbapedia.bulbagarden.net/wiki/String_Shot_(move)