### PR TITLE
Fix Hoopa Back Sprite Coordinates

### DIFF
--- a/src/data/pokemon_graphics/back_pic_coordinates.h
+++ b/src/data/pokemon_graphics/back_pic_coordinates.h
@@ -3598,7 +3598,7 @@ const struct MonCoords gMonBackPicCoords[] =
     [SPECIES_HOOPA] =
     {
         .size = 0x87,
-        .y_offset = 7,
+        .y_offset = 8,
     },
     [SPECIES_VOLCANION] =
     {


### PR DESCRIPTION
was 1 pixel too high, causing a gap between the sprite and the textbox