### PR TITLE
Update Toxic Orb and Flame Orb strings

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -6411,14 +6411,26 @@ BattleScript_BufferEndTurn::
 BattleScript_ToxicOrb::
 	setbyte cMULTISTRING_CHOOSER, 0
 	copybyte gEffectBattler, gBattlerAttacker
-	call BattleScript_MoveEffectToxic
+	call BattleScript_MoveEffectToxicByItem
 	end2
+
+BattleScript_MoveEffectToxicByItem::
+	statusanimation BS_EFFECT_BATTLER
+	printstring STRINGID_PSNBYITEM
+	waitmessage 0x40
+	goto BattleScript_UpdateEffectStatusIconRet
 
 BattleScript_FlameOrb::
 	setbyte cMULTISTRING_CHOOSER, 0
 	copybyte gEffectBattler, gBattlerAttacker
-	call BattleScript_MoveEffectBurn
+	call BattleScript_MoveEffectBurnByItem
 	end2
+
+BattleScript_MoveEffectBurnByItem::
+	statusanimation BS_EFFECT_BATTLER
+	printfromtable gGotBurnedByItemStringIds
+	waitmessage 0x40
+	goto BattleScript_UpdateEffectStatusIconRet
 
 BattleScript_MoveEffectPoison::
 	statusanimation BS_EFFECT_BATTLER

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -1395,6 +1395,11 @@ const u16 gGotBurnedStringIds[] =
     STRINGID_PKMNWASBURNED, STRINGID_PKMNBURNEDBY
 };
 
+const u16 gGotBurnedByItemStringIds[] =
+{
+    STRINGID_BRNBYITEM, STRINGID_PKMNBURNEDBY
+};
+
 const u16 gGotFrozenStringIds[] =
 {
     STRINGID_PKMNWASFROZEN, STRINGID_PKMNFROZENBY


### PR DESCRIPTION
So they print why your Pokémon was burned/badly poisoned.
![image](https://user-images.githubusercontent.com/18596778/90330623-8791bc00-dfae-11ea-84c1-249962053769.png)